### PR TITLE
Dalacor UK VAT Return

### DIFF
--- a/UnitedKingdom/VatReturn.cs
+++ b/UnitedKingdom/VatReturn.cs
@@ -51,7 +51,10 @@ namespace ManagerExtensions.UnitedKingdom
             var G7 = taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_20 || x.TaxCode == TaxCodes.VAT_05 || x.TaxCode == TaxCodes.VAT_00 || x.TaxCode == TaxCodes.VAT_Exempt).Sum(x => x.NetPurchases);
             G7 += taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_20_ON_IMPORTS).Sum(x => x.TaxAmount) * 5;
             G7 += taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_05_ON_IMPORTS).Sum(x => x.TaxAmount) * 20;
-
+            var G8 = taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_20).Sum(x => x.NetSales);
+            var G9 = taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_20).Sum(x => x.NetPurchases);
+            G8 += taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_05_ON_IMPORTS).Sum(x => x.TaxAmount);
+            G8 += taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_20_ON_IMPORTS).Sum(x => x.TaxAmount);
             var G3 = G1 + G2;
             var G5 = G3 - G4;
 
@@ -80,37 +83,37 @@ namespace ManagerExtensions.UnitedKingdom
                 }
                 using (Tr())
                 {
-                    using (Td()) Write("VAT due this period on sales and other outputs");
+                    using (Td()) Write("VAT due this in this period on sales and other outputs");
                     using (Td(@class: "dollar-sign")) Write("£");
-                    using (Td(@class: "amount")) using (Div()) Write(G1.ToString("#,0"));
+                    using (Td(@class: "amount")) using (Div()) Write(G1.ToString("0.00"));
                     using (Td(@class: "gray")) using (Div()) Write("#1 on the VAT Return");
                 }
                 using (Tr())
                 {
                     using (Td()) Write("VAT due in this period on acquisitions from other EC Member States");
                     using (Td(@class: "dollar-sign")) Write("£");
-                    using (Td(@class: "amount")) using (Div()) Write(G2.ToString("#,0"));
+                    using (Td(@class: "amount")) using (Div()) Write(G2.ToString("0.00"));
                     using (Td(@class: "gray")) using (Div()) Write("#2 on the VAT Return");
                 }
                 using (Tr())
                 {
                     using (Td()) Write("<b>Total VAT due (the sum of boxes 1 and 2)</b>");
                     using (Td(@class: "dollar-sign")) Write("£");
-                    using (Td(@class: "amount")) using (Div()) Write(G3.ToString("#,0"));
+                    using (Td(@class: "amount")) using (Div()) Write(G3.ToString("0.00"));
                     using (Td(@class: "gray")) using (Div()) Write("#3 on the VAT Return");
                 }
                 using (Tr())
                 {
-                    using (Td()) Write("VAT reclaimed in this period on purchases and other inputs (including acquisitions from EC)");
+                    using (Td()) Write("VAT reclaimed in this period on purchases and other inputs (including acquisitions from the EC)");
                     using (Td(@class: "dollar-sign")) Write("£");
-                    using (Td(@class: "amount")) using (Div()) Write(G4.ToString("#,0"));
+                    using (Td(@class: "amount")) using (Div()) Write(G4.ToString("0.00"));
                     using (Td(@class: "gray")) using (Div()) Write("#4 on the VAT Return");
                 }
                 using (Tr(@class: "line"))
                 {
-                    using (Td()) Write("<b>Net VAT to be paid to Customs (or reclaimed by you)</b>");
+                    using (Td()) Write("<b>Net VAT to be paid to Customs or reclaimed by you (Difference between boxes 3 and 4)</b>");
                     using (Td(@class: "dollar-sign")) Write("£");
-                    using (Td(@class: "amount")) using (Div()) Write(G5.ToString("#,0"));
+                    using (Td(@class: "amount")) using (Div()) Write(G5.ToString("0.00"));
                     using (Td(@class: "gray")) using (Div()) Write("#5 on the VAT Return");
                 }
                 using (Tr(@class: "line"))
@@ -119,17 +122,31 @@ namespace ManagerExtensions.UnitedKingdom
                 }
                 using (Tr())
                 {
-                    using (Td()) Write("Total value of sales and all other outputs excluding VAT (including supplies to EC)");
+                    using (Td()) Write("Total value of sales and all other outputs excluding any VAT.  Include your box 8 figure.");
                     using (Td(@class: "dollar-sign")) Write("£");
                     using (Td(@class: "amount")) using (Div()) Write(G6.ToString("#,0"));
                     using (Td(@class: "gray")) using (Div()) Write("#6 on the VAT Return");
                 }
                 using (Tr())
                 {
-                    using (Td()) Write("Total value of purchases and all other inputs excluding VAT (including acquisitions from EC)");
+                    using (Td()) Write("Total value of purchases and all other inputs excluding any VAT.  Include your box 9 figure.");
                     using (Td(@class: "dollar-sign")) Write("£");
                     using (Td(@class: "amount")) using (Div()) Write(G7.ToString("#,0"));
                     using (Td(@class: "gray")) using (Div()) Write("#7 on the VAT Return");
+                }
+                using (Tr())
+                {
+                    using (Td()) Write("Total value of all supplies of goods and related costs, excluding any VAT, to other EC Member States.");
+                    using (Td(@class: "dollar-sign")) Write("£");
+                    using (Td(@class: "amount")) using (Div()) Write(G8.ToString("#,0"));
+                    using (Td(@class: "gray")) using (Div()) Write("#8 on the VAT Return");
+                }
+                using (Tr())
+                {
+                    using (Td()) Write("Total value of acquisitions of goods and related costs, excluding any VAT, from other EC Member States.");
+                    using (Td(@class: "dollar-sign")) Write("£");
+                    using (Td(@class: "amount")) using (Div()) Write(G9.ToString("#,0"));
+                    using (Td(@class: "gray")) using (Div()) Write("#9 on the VAT Return");
                 }
             }
         }

--- a/UnitedKingdom/VatReturn.cs
+++ b/UnitedKingdom/VatReturn.cs
@@ -55,6 +55,8 @@ namespace ManagerExtensions.UnitedKingdom
             var G9 = taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_20).Sum(x => x.NetPurchases);
             G8 += taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_05_ON_IMPORTS).Sum(x => x.TaxAmount);
             G8 += taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_20_ON_IMPORTS).Sum(x => x.TaxAmount);
+            G9 += taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_05_ON_IMPORTS).Sum(x => x.TaxAmount);
+            G9 += taxTransactions.Where(x => x.TaxCode == TaxCodes.VAT_20_ON_IMPORTS).Sum(x => x.TaxAmount);
             var G3 = G1 + G2;
             var G5 = G3 - G4;
 


### PR DESCRIPTION
Following changes have hopefully been made.

1.  Boxes 1 to 5 are calucalating the amount to the penny.  Original document was set to drop the pennies.
2.  Created Boxes 8 and 9 with relevant content as these were missing from the original document
3.  Edited text throughout the document so that each section is identical to the UK VAT Return.
4.  Disclaimer.  Not entirely certain that the coding for Boxes 8 and 9 are correct.  But the text that I have supplied in boxes 8 and 9 should be self explanatory as to what figures should be in those boxes.  Could someone who is more experienced with coding check that I have done the coding correctly to pull the correct figures into these boxes.  Please check, as I don't think that its 100% correct.